### PR TITLE
feat(core): use interfaces to assign names to computed types

### DIFF
--- a/examples/test/__snapshots__/snapshot-tests.js.snap
+++ b/examples/test/__snapshots__/snapshot-tests.js.snap
@@ -923,7 +923,7 @@ Object {
                     "ParameterName": "LambdaArn",
                     "ParameterValue": Object {
                       "Fn::GetAtt": Array [
-                        "LakeDatabasedataPointsToS3Processor72949AE3",
+                        "LakeDatabasedataPointsToS3ValidatorProcessor676DF886",
                         "Arn",
                       ],
                     },
@@ -1078,7 +1078,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "LakeDatabasedataPointsToS3Processor72949AE3",
+                  "LakeDatabasedataPointsToS3ValidatorProcessor676DF886",
                   "Arn",
                 ],
               },
@@ -1095,14 +1095,14 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "LakeDatabasedataPointsToS3Processor72949AE3": Object {
+    "LakeDatabasedataPointsToS3ValidatorProcessor676DF886": Object {
       "Properties": Object {
         "Code": Object {
           "ZipFile": "exports.handler = function(){ throw new Error(\\"Mocked code is running, oops!\\");}",
         },
         "Environment": Object {
           "Variables": Object {
-            "bootstrap_construct_path": "data-lake/Lake/Database/dataPoints/ToS3/Processor",
+            "bootstrap_construct_path": "data-lake/Lake/Database/dataPoints/ToS3/Validator/Processor",
             "entrypoint_id": "1",
             "is_runtime": "true",
           },
@@ -1111,7 +1111,7 @@ Object {
         "MemorySize": 256,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "LakeDatabasedataPointsToS3ProcessorServiceRole1138340D",
+            "LakeDatabasedataPointsToS3ValidatorProcessorServiceRoleD02004B2",
             "Arn",
           ],
         },
@@ -1120,7 +1120,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "LakeDatabasedataPointsToS3ProcessorServiceRole1138340D": Object {
+    "LakeDatabasedataPointsToS3ValidatorProcessorServiceRoleD02004B2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -4032,7 +4032,7 @@ Object {
                     "ParameterName": "LambdaArn",
                     "ParameterValue": Object {
                       "Fn::GetAtt": Array [
-                        "ToS3Processor14BA5FE8",
+                        "ToS3ValidatorProcessorD6994816",
                         "Arn",
                       ],
                     },
@@ -4187,7 +4187,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ToS3Processor14BA5FE8",
+                  "ToS3ValidatorProcessorD6994816",
                   "Arn",
                 ],
               },
@@ -4204,14 +4204,14 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ToS3Processor14BA5FE8": Object {
+    "ToS3ValidatorProcessorD6994816": Object {
       "Properties": Object {
         "Code": Object {
           "ZipFile": "exports.handler = function(){ throw new Error(\\"Mocked code is running, oops!\\");}",
         },
         "Environment": Object {
           "Variables": Object {
-            "bootstrap_construct_path": "stream-processing/ToS3/Processor",
+            "bootstrap_construct_path": "stream-processing/ToS3/Validator/Processor",
             "entrypoint_id": "14",
             "is_runtime": "true",
           },
@@ -4220,7 +4220,7 @@ Object {
         "MemorySize": 256,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "ToS3ProcessorServiceRoleECCCE576",
+            "ToS3ValidatorProcessorServiceRole49E084BB",
             "Arn",
           ],
         },
@@ -4229,7 +4229,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "ToS3ProcessorServiceRoleECCCE576": Object {
+    "ToS3ValidatorProcessorServiceRole49E084BB": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [

--- a/packages/punchcard/lib/dynamodb/client.ts
+++ b/packages/punchcard/lib/dynamodb/client.ts
@@ -1,7 +1,7 @@
 
 import AWS = require('aws-sdk');
 
-import { RuntimeShape, Shape } from '../shape/shape';
+import { RuntimeShape } from '../shape/shape';
 import { StructShape } from '../shape/struct';
 import { CompiledExpression } from './expression/compile-context';
 import { CompileContextImpl } from './expression/compiler';

--- a/packages/punchcard/lib/firehose/client.ts
+++ b/packages/punchcard/lib/firehose/client.ts
@@ -4,7 +4,9 @@ import { Json, Mapper, Shape } from '../shape';
 import { Sink, sink, SinkProps } from '../util/sink';
 import { DeliveryStream } from './delivery-stream';
 
-export type PutRecordInput<T> = { Record: T; };
+export interface PutRecordInput<T> {
+  Record: T;
+}
 
 export class Client<T> implements Sink<T> {
   public readonly mapper: Mapper<T, string>;

--- a/packages/punchcard/lib/firehose/delivery-stream.ts
+++ b/packages/punchcard/lib/firehose/delivery-stream.ts
@@ -188,6 +188,7 @@ class Validator<S extends Shape<any>> {
   public readonly processor: Function<FirehoseEvent, FirehoseResponse, Dependency.None>;
 
   constructor(scope: Build<core.Construct>, id: string, props: ValidatorProps<S>) {
+    scope = scope.map(scope => new core.Construct(scope, id));
     const executorService = props.executorService || new ExecutorService({
       memorySize: 256,
       timeout: core.Duration.seconds(60)

--- a/packages/punchcard/lib/glue/table.ts
+++ b/packages/punchcard/lib/glue/table.ts
@@ -21,16 +21,16 @@ import { Sink } from '../util/sink';
 /**
  * A Glue Table's Columns.
  */
-export type Columns = {
+export interface Columns {
   [key: string]: Shape<any>;
-};
+}
 
 /**
  * A Glue Table's Partition Keys.
  */
-export type PartitionKeys = {
+export interface PartitionKeys {
   [key: string]: Shape<string> | Shape<number>;
-};
+}
 
 /**
  * Augmentation of `glue.TableProps`, using a `Shape` to define the
@@ -235,21 +235,21 @@ export class Table<C extends Columns, P extends PartitionKeys> implements Resour
   /**
    * Runtime dependency with read/write access to the Table and S3 Bucket.
    */
-  public readWriteAccess(): Dependency<Table.ReadWriteClient<C, P>> {
+  public readWriteAccess(): Dependency<Table.ReadWrite<C, P>> {
     return this.client((t, g) => t.grantReadWrite(g), this.bucket.readWriteAccess());
   }
 
   /**
    * Runtime dependency with read access to the Table and S3 Bucket.
    */
-  public readAccess(): Dependency<Table.ReadClient<C, P>> {
+  public readAccess(): Dependency<Table.ReadOnly<C, P>> {
     return this.client((t, g) => t.grantRead(g), this.bucket.readAccess());
   }
 
   /**
    * Runtime dependency with write access to the Table and S3 Bucket.
    */
-  public writeAccess(): Dependency<Table.WriteClient<C, P>> {
+  public writeAccess(): Dependency<Table.WriteOnly<C, P>> {
     return this.client((t, g) => t.grantWrite(g), this.bucket.writeAccess());
   }
 
@@ -279,9 +279,9 @@ export namespace Table {
   /**
    * Client type aliaes.
    */
-  export type ReadWriteClient<C extends Columns, P extends PartitionKeys> = Table.Client<C, P>;
-  export type ReadClient<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'batchCreatePartition' | 'createPartition' | 'updatePartition' | 'sink'>;
-  export type WriteClient<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'getPartitions'>;
+  export type ReadWrite<C extends Columns, P extends PartitionKeys> = Table.Client<C, P>;
+  export type ReadOnly<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'batchCreatePartition' | 'createPartition' | 'updatePartition' | 'sink'>;
+  export type WriteOnly<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'getPartitions'>;
 
   /**
    * Request and Response aliases.

--- a/packages/punchcard/lib/glue/table.ts
+++ b/packages/punchcard/lib/glue/table.ts
@@ -279,22 +279,29 @@ export namespace Table {
   /**
    * Client type aliaes.
    */
-  export type ReadWrite<C extends Columns, P extends PartitionKeys> = Table.Client<C, P>;
-  export type ReadOnly<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'batchCreatePartition' | 'createPartition' | 'updatePartition' | 'sink'>;
-  export type WriteOnly<C extends Columns, P extends PartitionKeys> = Omit<Table.Client<C, P>, 'getPartitions'>;
+  export interface ReadWrite<C extends Columns, P extends PartitionKeys> extends Table.Client<C, P> {}
+  export interface ReadOnly<C extends Columns, P extends PartitionKeys> extends Omit<Table.Client<C, P>, 'batchCreatePartition' | 'createPartition' | 'updatePartition' | 'sink'> {}
+  export interface WriteOnly<C extends Columns, P extends PartitionKeys> extends Omit<Table.Client<C, P>, 'getPartitions'> {}
 
   /**
    * Request and Response aliases.
    */
-  export type GetPartitionsRequest = Omit<AWS.Glue.GetPartitionsRequest, 'CatalogId' | 'DatabaseName' | 'TableName'>;
-  export type GetPartitionsResponse<P extends PartitionKeys> = {Partitions: Array<{
+  export interface GetPartitionsRequest extends Omit<AWS.Glue.GetPartitionsRequest, 'CatalogId' | 'DatabaseName' | 'TableName'> {}
+  export interface GetPartitionsResponse<P extends PartitionKeys> extends _GetPartitionsResponse<P> {}
+  type _GetPartitionsResponse<P extends PartitionKeys> = {Partitions: Array<{
     Values: RuntimeShape<StructShape<P>>;
   } & Omit<AWS.Glue.Partition, 'Values'>>};
-  export type CreatePartitionRequest<P extends PartitionKeys> = {Partition: RuntimeShape<StructShape<P>>, Location: string, LastAccessTime?: Date} &  Omit<AWS.Glue.PartitionInput, 'Values' | 'StorageDescriptor'>;
-  export type CreatePartitionResponse = AWS.Glue.CreatePartitionResponse;
-  export type BatchCreatePartitionRequestEntry<P extends PartitionKeys> = CreatePartitionRequest<P>;
-  export type BatchCreatePartitionRequest<P extends PartitionKeys> = Array<BatchCreatePartitionRequestEntry<P>>;
-  export type UpdatePartitionRequest<P extends PartitionKeys> = {Partition: RuntimeShape<StructShape<P>>, UpdatedPartition: CreatePartitionRequest<P>};
+
+  export interface CreatePartitionRequest<P extends PartitionKeys> extends _CreatePartitionRequest<P> {}
+  type _CreatePartitionRequest<P extends PartitionKeys> = {Partition: RuntimeShape<StructShape<P>>, Location: string, LastAccessTime?: Date} &  Omit<AWS.Glue.PartitionInput, 'Values' | 'StorageDescriptor'>;
+
+  export interface CreatePartitionResponse extends AWS.Glue.CreatePartitionResponse {}
+  export interface BatchCreatePartitionRequestEntry<P extends PartitionKeys> extends CreatePartitionRequest<P> {}
+  export interface BatchCreatePartitionRequest<P extends PartitionKeys> extends Array<BatchCreatePartitionRequestEntry<P>> {}
+  export interface UpdatePartitionRequest<P extends PartitionKeys> {
+    Partition: RuntimeShape<StructShape<P>>,
+    UpdatedPartition: CreatePartitionRequest<P>
+  }
 
   /**
    * Client for interacting with a Glue Table:

--- a/packages/punchcard/lib/kinesis/records.ts
+++ b/packages/punchcard/lib/kinesis/records.ts
@@ -6,7 +6,8 @@ import { Stream as SStream } from '../util/stream';
 import { Event } from './event';
 import { Stream } from './stream';
 
-export type Config = SStream.Config & events.KinesisEventSourceProps;
+export interface Config extends _Config {}
+type _Config = SStream.Config & events.KinesisEventSourceProps;
 
 /**
  * A `Stream` of Records from a Kinesis Stream.

--- a/packages/punchcard/lib/kinesis/stream.ts
+++ b/packages/punchcard/lib/kinesis/stream.ts
@@ -88,21 +88,21 @@ export class Stream<S extends Shape<any>> implements Resource<kinesis.Stream> {
   /**
    * Read and Write access to this stream.
    */
-  public readWriteAccess(): Dependency<Client<S>> {
+  public readWriteAccess(): Dependency<Stream.ReadWrite<S>> {
     return this.dependency((stream, g) => stream.grantReadWrite(g));
   }
 
   /**
    * Read-only access to this stream.
    */
-  public readAccess(): Dependency<Client<S>> {
+  public readAccess(): Dependency<Stream.ReadOnly<S>> {
     return this.dependency((stream, g) => stream.grantRead(g));
   }
 
   /**
    * Write-only access to this stream.
    */
-  public writeAccess(): Dependency<Client<S>> {
+  public writeAccess(): Dependency<Stream.WriteOnly<S>> {
     return this.dependency((stream, g) => stream.grantWrite(g));
   }
 
@@ -119,4 +119,10 @@ export class Stream<S extends Shape<any>> implements Resource<kinesis.Stream> {
           cache.getOrCreate('aws:kinesis', () => new AWS.Kinesis())) as any)
     };
   }
+}
+
+export namespace Stream {
+  export interface ReadOnly<S extends Shape<any>> extends Omit<Client<S>, 'putRecord' | 'putRecords' | 'sink'> {}
+  export interface WriteOnly<S extends Shape<any>> extends Omit<Client<S>, 'getRecords'> {}
+  export interface ReadWrite<S extends Shape<any>> extends Client<S> {}
 }

--- a/packages/punchcard/lib/lambda/schedule.ts
+++ b/packages/punchcard/lib/lambda/schedule.ts
@@ -9,7 +9,8 @@ import { Client } from '../core/client';
 import { Dependency } from '../core/dependency';
 import { Function, FunctionProps } from './function';
 
-export type ScheduleProps<D extends Dependency<any>> = FunctionProps<CloudWatch.Event, any, D> & {
+export interface ScheduleProps<D extends Dependency<any>> extends _ScheduleProps<D> {}
+type _ScheduleProps<D extends Dependency<any>> = FunctionProps<CloudWatch.Event, any, D> & {
   schedule: events.Schedule;
 };
 

--- a/packages/punchcard/lib/s3/client.ts
+++ b/packages/punchcard/lib/s3/client.ts
@@ -1,15 +1,15 @@
-export type ReadWriteClient = Client;
-export type DeleteClient = Pick<Client, 'deleteObject' | 'bucketName' | 'client'>;
-export type PutClient = Pick<Client, 'putObject' | 'bucketName' | 'client'>;
-export type ReadClient = Omit<Client, 'deleteObject' | 'putObject'>;
-export type WriteClient = Omit<Client, 'getObject' | 'headObject' | 'listObjectsV2' | 'listObjectsV2'>;
+export interface ReadWriteClient extends Client {}
+export interface DeleteClient extends Pick<Client, 'deleteObject' | 'bucketName' | 'client'> {}
+export interface PutClient extends Pick<Client, 'putObject' | 'bucketName' | 'client'> {}
+export interface ReadClient extends Omit<Client, 'deleteObject' | 'putObject'> {}
+export interface WriteClient extends Omit<Client, 'getObject' | 'headObject' | 'listObjectsV2' | 'listObjectsV2'> {}
 
-export type DeleteObjectRequest = Omit<AWS.S3.DeleteObjectRequest, 'Bucket'>;
-export type GetObjectRequest = Omit<AWS.S3.GetObjectRequest, 'Bucket'>;
-export type HeadObjectRequest = Omit<AWS.S3.HeadObjectRequest, 'Bucket'>;
-export type ListObjectsRequest = Omit<AWS.S3.ListObjectsRequest, 'Bucket'>;
-export type ListObjectsV2Request = Omit<AWS.S3.ListObjectsV2Request, 'Bucket'>;
-export type PutObjectRequest = Omit<AWS.S3.PutObjectRequest, 'Bucket'>;
+export interface DeleteObjectRequest extends Omit<AWS.S3.DeleteObjectRequest, 'Bucket'> {}
+export interface GetObjectRequest extends Omit<AWS.S3.GetObjectRequest, 'Bucket'> {}
+export interface HeadObjectRequest extends Omit<AWS.S3.HeadObjectRequest, 'Bucket'> {}
+export interface ListObjectsRequest extends Omit<AWS.S3.ListObjectsRequest, 'Bucket'> {}
+export interface ListObjectsV2Request extends Omit<AWS.S3.ListObjectsV2Request, 'Bucket'> {}
+export interface PutObjectRequest extends Omit<AWS.S3.PutObjectRequest, 'Bucket'> {}
 
 export class Client {
   constructor(

--- a/packages/punchcard/lib/s3/notifications.ts
+++ b/packages/punchcard/lib/s3/notifications.ts
@@ -6,7 +6,8 @@ import { Stream } from '../util/stream';
 import { Bucket } from './bucket';
 import { Event } from './event';
 
-export type ObjectStreamConfig = Stream.Config & events.S3EventSourceProps;
+type _ObjectStreamConfig = Stream.Config & events.S3EventSourceProps;
+export interface ObjectStreamConfig extends _ObjectStreamConfig {}
 
 /**
  * A `Stream` of S3 Notifications from a S3 Bucket.

--- a/packages/punchcard/lib/sns/topic.ts
+++ b/packages/punchcard/lib/sns/topic.ts
@@ -16,12 +16,14 @@ import { Sink, sink, SinkProps } from '../util/sink';
 import { Event } from './event';
 import { Notifications } from './notifications';
 
-export type TopicProps<S extends Shape<any>> = {
+type _TopicProps<S extends Shape<any>> = {
   /**
    * Shape of notifications emitted from the Topic.
    */
   shape: S;
 } & sns.TopicProps;
+
+export interface TopicProps<S extends Shape<any>> extends _TopicProps<S> {}
 
 /**
  * A SNS `Topic` with notifications of type, `T`.
@@ -114,8 +116,10 @@ export class Topic<S extends Shape<any>> implements Resource<sns.Topic> {
 }
 
 export namespace Topic {
-  export type PublishInput<T> = {Message: T} & Pick<AWS.SNS.PublishInput, 'MessageAttributes' | 'MessageStructure'>;
-  export type PublishResponse = AWS.SNS.PublishResponse;
+  type _PublishInput<T> = {Message: T} & Pick<AWS.SNS.PublishInput, 'MessageAttributes' | 'MessageStructure'>;
+  export interface PublishInput<T>  extends _PublishInput<T> {}
+
+  export interface PublishResponse extends AWS.SNS.PublishResponse {}
 
   /**
    * A client to a specific SNS `Topic` with messages of some type, `T`.

--- a/packages/punchcard/lib/sqs/messages.ts
+++ b/packages/punchcard/lib/sqs/messages.ts
@@ -5,7 +5,8 @@ import { Stream } from '../util/stream';
 import { Event } from './event';
 import { Queue } from './queue';
 
-export type Config = Stream.Config & events.SqsEventSourceProps;
+export interface Config extends _Config {}
+type _Config = Stream.Config & events.SqsEventSourceProps;
 
 /**
  * A `Stream` of Messages from a SQS Queue.

--- a/packages/punchcard/lib/sqs/queue.ts
+++ b/packages/punchcard/lib/sqs/queue.ts
@@ -166,7 +166,7 @@ export namespace Queue {
         Entries: request.map(record => ({
           ...record,
           MessageBody: this.mapper.write(record.MessageBody)
-        })) as any
+        }))
       }).promise();
     }
 

--- a/packages/punchcard/lib/sqs/queue.ts
+++ b/packages/punchcard/lib/sqs/queue.ts
@@ -107,16 +107,20 @@ export class Queue<S extends Shape<any>> implements Resource<sqs.Queue> {
  * Namespace for `Queue` type aliases and its `Client` implementation.
  */
 export namespace Queue {
-  export type ConsumeAndSendClient<T extends Shape<any>> = Client<T>;
-  export type ConsumeClient<T extends Shape<any>> = Omit<Client<T>, 'sendMessage' | 'sendMessageBatch'>;
-  export type SendClient<T extends Shape<any>> = Omit<Client<T>, 'receiveMessage'>;
+  export interface ConsumeAndSendClient<T extends Shape<any>> extends Client<T> {}
+  export interface ConsumeClient<T extends Shape<any>> extends Omit<Client<T>, 'sendMessage' | 'sendMessageBatch'> {}
+  export interface SendClient<T extends Shape<any>> extends Omit<Client<T>, 'receiveMessage'> {}
 
-  export type ReceiveMessageRequest = Omit<AWS.SQS.ReceiveMessageRequest, 'QueueUrl'>;
+  export interface ReceiveMessageRequest extends Omit<AWS.SQS.ReceiveMessageRequest, 'QueueUrl'> {}
   export type ReceiveMessageResult<T extends Shape<any>> = Array<{Body: RuntimeShape<T>} & Omit<AWS.SQS.Message, 'Body'>>;
   export type SendMessageRequest<T extends Shape<any>> = {MessageBody: RuntimeShape<T>} & Omit<AWS.SQS.SendMessageRequest, 'QueueUrl' | 'MessageBody'>;
-  export type SendMessageResult = AWS.SQS.SendMessageResult;
-  export type SendMessageBatchRequest<T extends Shape<any>> = Array<{MessageBody: RuntimeShape<T>} & Omit<AWS.SQS.SendMessageBatchRequestEntry, 'MessageBody'>>;
-  export type SendMessageBatchResult = AWS.SQS.SendMessageBatchResult;
+  export interface SendMessageResult extends AWS.SQS.SendMessageResult {}
+
+  export interface SendMessageBatchRequestEntry<T extends Shape<any>> extends _SendMessageBatchRequestEntry<T> {}
+  type _SendMessageBatchRequestEntry<T extends Shape<any>> = {MessageBody: RuntimeShape<T>} & Omit<AWS.SQS.SendMessageBatchRequestEntry, 'MessageBody'>;
+
+  export interface SendMessageBatchRequest<T extends Shape<any>> extends Array<SendMessageBatchRequestEntry<T>> {}
+  export interface SendMessageBatchResult extends AWS.SQS.SendMessageBatchResult {}
 
   /**
    * Runtime representation of a SQS Queue.
@@ -156,13 +160,13 @@ export namespace Queue {
     /**
      * Delivers a batch of messages to the specified queue.
      */
-    public sendMessageBatch(request: SendMessageBatchRequest<T>): Promise<AWS.SQS.SendMessageBatchResult> {
+    public sendMessageBatch(request: SendMessageBatchRequest<T>): Promise<SendMessageBatchResult> {
       return this.client.sendMessageBatch({
         QueueUrl: this.queueUrl,
         Entries: request.map(record => ({
           ...record,
           MessageBody: this.mapper.write(record.MessageBody)
-        }))
+        })) as any
       }).promise();
     }
 

--- a/packages/punchcard/tslint.yaml
+++ b/packages/punchcard/tslint.yaml
@@ -7,6 +7,7 @@ rules:
     member-ordering: false
     ordered-imports: true
     max-line-length: false
+    no-empty-interface: false
 
     # Due to VSCode syntax highlighting we're unlikely to do this wrong, and it gets annoying
     # when trying to construct literal Fn::Sub() arguments.


### PR DESCRIPTION
We compute types everywhere in Punchcard which can result in some gnarly type signatures that are quite difficult to read.

This happens because we use type aliases instead of using interfaces.
```ts
//before
export type ReadOnly<PKey extends keyof A, SKey extends keyof A | undefined, A extends Attributes> = Omit<Client<PKey, SKey, A>, 'put' | 'putBatch' | 'delete' | 'update'>;
// now
export interface ReadOnly<PKey extends keyof A, SKey extends keyof A | undefined, A extends Attributes> extends Omit<Client<PKey, SKey, A>, 'put' | 'putBatch' | 'delete' | 'update'> {}
```

A type alias has no identifier at compile time. It is simply an alias/pointer to another type. This results in ugly names, especially when using computations like Omit:
```ts
Omit<Client<T>, 'putRecord' | 'putRecords' | 'sink'>
```

Interfaces are the opposite - they give names to things for the TS compiler. This change uses this feature to provide more helpful names to Punchcard types:
```ts
// type reported now
Kinesis.Stream.ReadWrite<T>
// before
Omit<Client<T>, 'putRecord' | 'putRecords' | 'sink'>
```

Breaking Change: Moved the Firehose Validator construct under its own Construct.