### PR TITLE
Update docs to say 'Type' instead of 'Record'

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Furthermore, its interface is higher-level than what would normally be expected 
 /**
  * Message is a JSON Object with properties: `key`, `count` and `timestamp`.
  */
-class NotificationRecord extends Record({
+class NotificationRecord extends Type({
   key: string,
   count: integer,
   timestamp
@@ -90,7 +90,7 @@ This feature in punchcard becomes even more evident when using DynamoDB. To demo
 
 ```ts
 // class describing the data in the DynamoDB Table
-class TableRecord extends Record({
+class TableRecord extends Type({
   id: string,
   count: integer
     .apply(Minimum(0))
@@ -195,7 +195,7 @@ const queue = topic.toSQSQueue(stack, 'MyNewQueue');
 We can then, perhaps, `map` over each message in the `Queue` and collect the results into a new AWS Kinesis `Stream`:
 
 ```ts
-class LogDataRecord extends Record({
+class LogDataRecord extends Type({
   key: string,
   count: integer,
   tags: array(string)

--- a/docs/4-shapes.md
+++ b/docs/4-shapes.md
@@ -4,7 +4,7 @@ Data structures in punchcard are like ordinary collections such as an `Array<T>`
 Shapes are an in-code abstraction for (and agnostic to) data and schema formats such as JSON Schema, Glue Tables, DynamoDB, and (soon) Avro, Protobuf, Parquet, Orc.
 
 ```ts
-class NotificationRecord extends Record({
+class NotificationRecord extends Type({
   key: string,
   count: integer
     .apply(Minimum(0)), // apply a Trait to constrain the value of this integer
@@ -51,7 +51,7 @@ The framework makes use of Shapes to type-check your code against its schema and
 
 For reference, the above Topic's Shape:
 ```ts
-class NotificationRecord extends Record({
+class NotificationRecord extends Type({
   key: string,
   count: integer
     .apply(Minimum(0)),

--- a/docs/5-dynamodb-dsl.md
+++ b/docs/5-dynamodb-dsl.md
@@ -4,7 +4,7 @@ Punchcard uses TypeScript's [Advanced Types](https://www.typescriptlang.org/docs
 
 To demonstrate, let's create a `DynamoDB.Table` "with some Shape":
 ```ts
-class TableRecord extends Record({
+class TableRecord extends Type({
   id: string,
   count: integer
 }) {}

--- a/docs/6-stream-processing.md
+++ b/docs/6-stream-processing.md
@@ -6,7 +6,7 @@ Data structures that implement `Stream` are: `SNS.Topic`, `SQS.Queue`, `Kinesis.
 
 Given an `SNS.Topic`:
 ```ts
-class NotificationRecord extends Record({
+class NotificationRecord extends Type({
   key: string,
   count: integer,
   timestamp
@@ -43,7 +43,7 @@ These functions are called `Collectors` and they follow the naming convention `t
 We can then, perhaps, `map` over each message in the `Queue` and collect the results into a new AWS Kinesis `Stream`:
 
 ```ts
-class StreamDataRecord extends Record({
+class StreamDataRecord extends Type({
   key: string,
   count: integer,
   tags: array(string),

--- a/packages/@punchcard/shape-dynamodb/README.md
+++ b/packages/@punchcard/shape-dynamodb/README.md
@@ -7,7 +7,7 @@ This library extends the Punchcard Shape Type-System to provide a high-level abs
 The type of data in a Table is defined as a class with properties that represent its "Shape".
 
 ```ts
-class Type extends Record({
+class Type extends Type({
   key: string;
   count: number;
   list: array(string);

--- a/packages/@punchcard/shape-hive/README.md
+++ b/packages/@punchcard/shape-hive/README.md
@@ -1,8 +1,8 @@
 # @punchcard/shape-hive
 
-Maps a Punchcard Shape Record to its corresponding Hive Schema compatible with AWS Glue.
+Maps a Punchcard Shape Type to its corresponding Hive Schema compatible with AWS Glue.
 
-# Define a Schema with a Record
+# Define a Schema with a Type
 
 ```ts
 import { string, integer, number, array, set, map, Description } from '@punchcard/shape';
@@ -11,11 +11,11 @@ import { string, integer, number, array, set, map, Description } from '@punchcar
 import { double, float, char, varchar, Glue } from '@punchcard/shape-hive';
 
 // a record to be used within our top-level type (i.e. a nested structure).
-class Nested extends Record({
+class Nested extends Type({
   name: string
 }) {}
 
-class Data extends Record({
+class Data extends Type({
   id: string
     .apply(Description('this is a comment')),
 

--- a/packages/@punchcard/shape-json/README.md
+++ b/packages/@punchcard/shape-json/README.md
@@ -2,10 +2,10 @@
 
 Provides JSON serialization and deserialization for Punchcard Shapes.
 
-# Create a Record
+# Create a Type
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   key: string
     .apply(MinLength(1)), // apply constraints with Traits
   count: integer

--- a/packages/@punchcard/shape-jsonpath/README.md
+++ b/packages/@punchcard/shape-jsonpath/README.md
@@ -5,7 +5,7 @@ This library extends the Punchcard Shape Type-System with support for a type-saf
 # Define a Type
 ```ts
 // a record to be used within our top-level type (i.e. a nested structure).
-export class Nested extends Record({
+export class Nested extends Type({
   /**
    * This is a nested string.
    */
@@ -13,7 +13,7 @@ export class Nested extends Record({
 }) {}
 
 // the type we will query with JSON path
-export class MyType extends Record({
+export class MyType extends Type({
   /**
    * Field documentation.
    */

--- a/packages/@punchcard/shape-jsonschema/README.md
+++ b/packages/@punchcard/shape-jsonschema/README.md
@@ -4,9 +4,9 @@ This library maps types in the Punchcard Shape type-system to a JSON Schema.
 
 # Defining Types
 
-First, create a Record using the Shape type-sytem:
+First, create a Type using the Shape type-sytem:
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   key: string
     .apply(MinLength(1)),
   count: integer

--- a/packages/@punchcard/shape/README.md
+++ b/packages/@punchcard/shape/README.md
@@ -54,7 +54,7 @@ Punchcard Shapes is another workaround, except it eliminates the above redundanc
 Types are constructed in the same way as ordinary data in JavaScript!
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   /**
    * In-line documentation goes here.
    */
@@ -102,7 +102,7 @@ What about decorators though?
 Decorators in TypeScript can only be declared on top-level declarations, so we can not apply them to the arguments passed in to `Record`:
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   @Decorator() // not possible, bummer
   items: array(string)
 }) {}
@@ -111,7 +111,7 @@ class MyType extends Record({
 To use ordinary decorators, you must redundantly declare the member:
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   items: array(string)
 }) {
   @Decorator() // possible
@@ -124,7 +124,7 @@ This is unfortunate, but it is par for the course when compared to the `type-gra
 To eiminate this redundancy, Shapes also provide its own decorator replacement called "Traits". Any Shape can have a trait "applied" to it:
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   items: array(string)
     .apply(Trait())
 }) {}
@@ -135,7 +135,7 @@ Traits take decorators even further, however, as they can also augment the type-
 For example, the minimum value of an integer can be annotated on the type and used in type-level machinery to change behavior:
 
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   myNumber: integer
     .apply(Minimum(0))
 }) {}
@@ -164,7 +164,7 @@ Traits are used to annotate records with validation information. Common use-case
 
 ### `Optional` - mark a member as optional, equivalent to `?` in TS.
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   key: string.apply(Optional),
   // or use short-hand
   shortHand: optional(string)
@@ -178,7 +178,7 @@ const myType = new MyType({}); // still compiles if we don't provide a value for
 
 ### Min/Max numbers
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   myNumber: number
     .apply(Minimum(0))
     .apply(Maximum(256))
@@ -187,7 +187,7 @@ class MyType extends Record({
 
 ### Min/Max length of a string
 ```ts
-class MyType extends Record({
+class MyType extends Type({
   myNumber: string
     .apply(MinLength(0))
     .apply(MaxLength(256))
@@ -212,5 +212,5 @@ class MyType extends Record({
 * `set(T)` - a set of items, equivalent to `Set<T>` in TS, but also supports a non-primitive `T`.
 * `map(T)` - a map of string keys to values, equivalent to `{[key: string]: T; }` in TS.
 
-## Record
-* `Record(M)` - a class with named and well-typed members:
+## Type
+* `Type(M)` - a class with named and well-typed members:


### PR DESCRIPTION
Update documentation's use of `Record` with `Type` for shape creation.

Signed-off-by: Ryan Marsh <ryan@stochastic.dev>